### PR TITLE
Link logs

### DIFF
--- a/bin/main.ts
+++ b/bin/main.ts
@@ -14,11 +14,6 @@ yargs(process.argv.slice(2))
 	.wrap(terminalWidth)
 	.showHelpOnFail(false)
 	.strict(true)
-	.middleware((args: any) => {
-		if (args.cwd && args.cwd.startsWith(process.env.HOME)) {
-			args.cwd = args.cwd.replace(process.env.HOME, "~");
-		}
-	})
 	.option("cwd", {
 		alias: "c",
 		describe: "Custom current working directory",

--- a/src/actions_utils.ts
+++ b/src/actions_utils.ts
@@ -57,7 +57,7 @@ export class ActionOutputPrinter {
 		this.termBuffer = splitString + splittedTermbuffer[splittedTermbuffer.length - 1];
 
 		// Remove cursor restore
-		this.termBuffer = this.termBuffer.replace("\u001b8", "")
+		this.termBuffer = this.termBuffer.replace("\u001b8", "");
 
 		toWrite += this.termBuffer;
 		toWrite += ansiEscapes.cursorDown(1);
@@ -221,15 +221,15 @@ export class ActionOutputPrinter {
 		assert(!isError, "At least one action failed");
 	};
 
-	static getLogFilePath = async (cwd: string, log: (GroupKey & ChildProcessOutput)): Promise<string> => {
+	static getLogFilePath = async (cwd: string, log: GroupKey & ChildProcessOutput): Promise<string> => {
 		const logsFolderPath = path.join(cwd, "logs");
 
 		if (!(await fs.pathExists(logsFolderPath))) {
 			await fs.mkdir(logsFolderPath);
 		}
-		
+
 		return path.join(logsFolderPath, `${log.action}-${log.group}-${log.project}.log`);
-	}
+	};
 
 	stashLogsToFile = async (logs: (GroupKey & ChildProcessOutput)[]) => {
 		for (const log of logs) {

--- a/src/actions_utils.ts
+++ b/src/actions_utils.ts
@@ -207,7 +207,7 @@ export class ActionOutputPrinter {
 		this.progressBar.update({ status: waitingOnToString(null) });
 		this.progressBar.stop();
 		// final flush
-		await this.printOutputLines();
+		this.printOutputLines();
 		await this.clearOutputLines();
 		const isError = await logActionOutput(stdoutBuffer, this.config.cwd);
 		if (this.config.searchFor) searchOutputForHints(this.config, stdoutBuffer);

--- a/src/actions_utils.ts
+++ b/src/actions_utils.ts
@@ -56,6 +56,9 @@ export class ActionOutputPrinter {
 		const splittedTermbuffer = this.termBuffer.split(splitString);
 		this.termBuffer = splitString + splittedTermbuffer[splittedTermbuffer.length - 1];
 
+		// Remove cursor restore
+		this.termBuffer = this.termBuffer.replace("\u001b8", "")
+
 		toWrite += this.termBuffer;
 		toWrite += ansiEscapes.cursorDown(1);
 		const width = process.stdout.columns;
@@ -177,6 +180,7 @@ export class ActionOutputPrinter {
 	};
 
 	runActionUtils = async (actionToRun: string, groupToRun: string): Promise<void> => {
+		this.lastFewLines = [];
 		const addToBufferStream = this.addToBufferStream;
 		this.bufferStream = new BufferStreamWithTty({
 			write(chunk, _, callback) {
@@ -205,7 +209,7 @@ export class ActionOutputPrinter {
 		// final flush
 		await this.printOutputLines();
 		await this.clearOutputLines();
-		const isError = logActionOutput(stdoutBuffer, this.config.cwd);
+		const isError = await logActionOutput(stdoutBuffer, this.config.cwd);
 		if (this.config.searchFor) searchOutputForHints(this.config, stdoutBuffer);
 		if (stdoutBuffer.length === 0) {
 			console.log(chalk`{yellow No actions was found for the provided action, group and project.}`);

--- a/src/search_output.ts
+++ b/src/search_output.ts
@@ -26,7 +26,7 @@ export async function logActionOutput(stdoutHistory: ActionOutput[], cwd: string
 		} else {
 			console.error(
 				chalk`{bgRed  FAIL } {bold ${entry.project}} failed running ${entry.action} ${entry.group}.` +
-					chalk` Output logs can be found in ${tildify(await ActionOutputPrinter.getLogFilePath(cwd, entry))}`,
+					chalk` Output logs can be found in {cyan ${tildify(await ActionOutputPrinter.getLogFilePath(cwd, entry))}}`,
 			);
 			isError = true;
 		}

--- a/src/search_output.ts
+++ b/src/search_output.ts
@@ -26,7 +26,7 @@ export async function logActionOutput(stdoutHistory: ActionOutput[], cwd: string
 		} else {
 			console.error(
 				chalk`{bgRed  FAIL } {bold ${entry.project}} failed running ${entry.action} ${entry.group}.` +
-					chalk`Output logs can be found in ${tildify(await ActionOutputPrinter.getLogFilePath(cwd, entry))}`,
+					chalk` Output logs can be found in ${tildify(await ActionOutputPrinter.getLogFilePath(cwd, entry))}`,
 			);
 			isError = true;
 		}

--- a/src/search_output.ts
+++ b/src/search_output.ts
@@ -26,7 +26,7 @@ export async function logActionOutput(stdoutHistory: ActionOutput[], cwd: string
 		} else {
 			console.error(
 				chalk`{bgRed  FAIL } {bold ${entry.project}} failed running ${entry.action} ${entry.group}.` +
-					chalk `Output logs can be found in ${await ActionOutputPrinter.getLogFilePath(cwd, entry)}`
+					chalk`Output logs can be found in ${tildify(await ActionOutputPrinter.getLogFilePath(cwd, entry))}`,
 			);
 			isError = true;
 		}

--- a/src/search_output.ts
+++ b/src/search_output.ts
@@ -6,8 +6,9 @@ import { ActionOutput } from "./actions";
 import template from "chalk/source/templates";
 import { printHeader } from "./utils";
 import tildify from "tildify";
+import { ActionOutputPrinter } from "./actions_utils";
 
-export function logActionOutput(stdoutHistory: ActionOutput[]): boolean {
+export async function logActionOutput(stdoutHistory: ActionOutput[], cwd: string): Promise<boolean> {
 	let isError = false;
 	for (const entry of stdoutHistory) {
 		if (entry.wasSkippedDuplicated) {
@@ -24,8 +25,8 @@ export function logActionOutput(stdoutHistory: ActionOutput[]): boolean {
 			);
 		} else {
 			console.error(
-				chalk`{bgRed  FAIL } {bold ${entry.project}} failed running ${entry.action} ${entry.group},` +
-					chalk` go to {cyan ${tildify(entry.dir ?? "")}} and run {blue ${entry.cmd?.join(" ")}} manually`,
+				chalk`{bgRed  FAIL } {bold ${entry.project}} failed running ${entry.action} ${entry.group}.` +
+					chalk `Output logs can be found in ${await ActionOutputPrinter.getLogFilePath(cwd, entry)}`
 			);
 			isError = true;
 		}

--- a/tests/action_utils.test.ts
+++ b/tests/action_utils.test.ts
@@ -145,4 +145,20 @@ describe("ActionOutputPrinter", () => {
 			expect(keys).toEqual([["action"], ["group"], ["projecta"]]);
 		});
 	});
+
+	describe("getLogFilePath", () => {
+		test("It creates the log folder if it does not exist", async () => {
+			fs.mkdir = jest.fn();
+			fs.pathExists = jest.fn().mockImplementation(() => Promise.resolve(false));
+
+			const logFilePath = await ActionOutputPrinter.getLogFilePath(cnfStub.cwd, {
+				action: "start",
+				group: "group1",
+				project: "projecta",
+			});
+
+			expect(logFilePath).toEqual("/home/user/gitte/logs/start-group1-projecta.log");
+			expect(fs.mkdir).toHaveBeenCalledTimes(1);
+		})
+	});
 });

--- a/tests/action_utils.test.ts
+++ b/tests/action_utils.test.ts
@@ -159,6 +159,6 @@ describe("ActionOutputPrinter", () => {
 
 			expect(logFilePath).toEqual("/home/user/gitte/logs/start-group1-projecta.log");
 			expect(fs.mkdir).toHaveBeenCalledTimes(1);
-		})
+		});
 	});
 });


### PR DESCRIPTION
Fixes a bug if an action finishes very fast, and initial progressbar is not printed, where it would jump up to previous progress bar.

Prints "check logs" instead of "go to and run manually" for failed actions.

