### PR TITLE
Join output when regex matching using newline

### DIFF
--- a/src/search_output.ts
+++ b/src/search_output.ts
@@ -93,7 +93,7 @@ export function searchOutputForHints(tasks: Task[], cfg: Config, action: string,
 function searchForRegex(searchFor: SearchFor, tasks: Task[], firstHint: boolean): boolean {
 	for (const task of tasks) {
 		if (!task.result) continue;
-		const outAsText = task.result.out.join("");
+		const outAsText = task.result.out.join("\n");
 		if (new RegExp(searchFor.regex, "g").test(outAsText)) {
 			if (firstHint) {
 				printHeader("Hints");


### PR DESCRIPTION
Multiline output gets joined without any delimiter. This causes problems if the regex match is not the last line, as any output after the regex match group will be included in the match.

This pull request aims to fix this by just joining the output lines with newline delimiter instead (/g) modifier is already used anyway.

### Example of bug

**Output**

```
Service started visit https://example.com
See also https://example2.com
```

**Gitte config**

```
...
    searchFor:
        - regex: "Service started visit (.*)"
           hint: "{inverse  INFO } service has started sucessfully - go visit it on {cyan {1}}"
```

***Actual output***

```
 INFO  service has started sucessfully - go visit it on https://example.comSee also https://example2.com
```